### PR TITLE
Feature/make idempotent

### DIFF
--- a/lib/spinjector.rb
+++ b/lib/spinjector.rb
@@ -20,15 +20,15 @@ OptionParser.new do |opts|
 end.parse!
 
 project_path = Dir.glob("*.xcodeproj").first
+raise "[Error] No xcodeproj found" unless !project_path.nil?
 project = Xcodeproj::Project.open(project_path)
-raise "[Error] No xcodeproj found" unless !project.nil?
 
 configuration_file_path = options[:configuration_path] || CONFIGURATION_FILE_PATH
 configuration = YAMLParser.new(configuration_file_path).configuration
 
 project_service = ProjectService.new(project)
-project_service.remove_all_scripts()
-project_service.add_scripts_in_targets(configuration)
+project_service.update_scripts_in_targets(configuration)
 
 project.save()
 puts "Success."
+

--- a/lib/spinjector/entity/script.rb
+++ b/lib/spinjector/entity/script.rb
@@ -38,6 +38,8 @@ class Script
             true
         when :after_compile, :after_headers
             false
+        when :after_all,
+            false
         else
             raise ArgumentError, "Unknown execution position `#{execution_position}`"
         end

--- a/lib/spinjector/entity/target.rb
+++ b/lib/spinjector/entity/target.rb
@@ -7,4 +7,8 @@ class Target
         @name = name
         @scripts = scripts || []
     end
+
+    def scripts_names
+        @scripts.map { |script| script.name }
+    end
 end

--- a/lib/spinjector/project_service.rb
+++ b/lib/spinjector/project_service.rb
@@ -35,15 +35,15 @@ class ProjectService
             end
             native_target_script_phases.each do |script_phase|
                 if scripts_to_apply.include?(script_phase.name)
-                  # Update existing script phase with new values
-                  script_configuration = target_configuration.scripts.find { |script|
-                      BUILD_PHASE_PREFIX + script.name == script_phase.name
-                  }
-                  update_script_in_target(script_phase, script_configuration, target)
-                  scripts_to_apply.delete(script_phase.name)
+                    # Update existing script phase with new values
+                    script_configuration = target_configuration.scripts.find { |script|
+                        BUILD_PHASE_PREFIX + script.name == script_phase.name
+                    }
+                    update_script_in_target(script_phase, script_configuration, target)
+                    scripts_to_apply.delete(script_phase.name)
                 elsif
-                  target.build_phases.delete(script_phase)
-                  # Remove now defunct script phase
+                    target.build_phases.delete(script_phase)
+                    # Remove now defunct script phase
                 end
             end
             # We may miss scripts that are yet to be added to the pbxproj target, this is fixed in the following method
@@ -76,14 +76,14 @@ class ProjectService
     # @param [Target] the target configuration describing the scripts to be added
     #
     def reorder_and_add_missing_script_phases_of(target, target_configuration)
-      target_configuration.scripts.each do |script|
-        current_phase = spinjector_managed_phases(target).find { |phase| phase.name == BUILD_PHASE_PREFIX + script.name }
-        if current_phase == nil
-            current_phase = add_script_in_target(script, target)
+        target_configuration.scripts.each do |script|
+            current_phase = spinjector_managed_phases(target).find { |phase| phase.name == BUILD_PHASE_PREFIX + script.name }
+            if current_phase == nil
+                current_phase = add_script_in_target(script, target)
+            end
+            execution_position = script.execution_position
+            reorder_script_phase(target, current_phase, execution_position)
         end
-        execution_position = script.execution_position
-        reorder_script_phase(target, current_phase, execution_position)
-      end
     end
 
     # @param [Script] script the script phase defined in configuration files to add to the target


### PR DESCRIPTION
Solves https://github.com/faberNovel/spinjector/issues/2

Made significant changes (hopefully improvements) on this.
The core of it is aimed at making the script idempotent.

To do so, the idea was to reuse previously created build_phases instead of deleting / recreating them.
First we needed to be able to know if any `[SPI] <BuildPhase>` was still in the current configuration. I chose to define the `name` of the scripts as unique identifiers.

Once this is set up, loop on the target build_phases, 
* delete them if the target is not in the yaml configuration file
* otherwise, update them accordingly
* loop on the configuration file, add missing (ie new, not yet added to the target) scripts
* reorder everything

The reordering was improved also.
Previously it ensured that the script position was right relative to the build_phase it wanted to position itself with.
Now, It is furthermore ordered according to the order defined in the yaml configuration file.

Lastly, added :after_all to add a script last in list. (For instance, Firebase Crashlytics requires this)

The big issue with all these changes is that is adds a lot of chances to fail, and it definitely calls for some testing.