### PR TITLE
Feature/add option to disable script dependency analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Created
 
+- Added `always_out_of_date` option to script to make Xcode always run them without dependency analysis.
+
 ### Fixed
 
 ### Removed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spinjector (0.0.6)
+    spinjector (1.0.0)
       optparse (~> 0.1)
       xcodeproj (~> 1.21)
       yaml (~> 0.2)
@@ -9,7 +9,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.5)
+    CFPropertyList (3.0.6)
       rexml
     ansi (1.5.0)
     atomos (0.1.3)
@@ -25,21 +25,21 @@ GEM
       minitest (>= 5.0)
       ruby-progressbar
     nanaimo (0.3.0)
-    optparse (0.2.0)
+    optparse (0.4.0)
     rake (12.3.3)
-    rexml (3.2.5)
+    rexml (3.2.6)
     ruby-progressbar (1.11.0)
-    xcodeproj (1.21.0)
+    xcodeproj (1.23.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
       rexml (~> 3.2.4)
-    yaml (0.2.0)
+    yaml (0.3.0)
 
 PLATFORMS
-  x86_64-darwin-18
+  ruby
 
 DEPENDENCIES
   bundler (>= 1.12.0, < 3.0.0)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
+.PHONY: test
+
 build:
 	gem build spinjector.gemspec
+
+test:
+	bundle exec rake test
 
 install: clean build
 	gem install spinjector-*.gem

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ dependency_file:                     # optional.
 execution_position:                  # optional. [:before_compile | :after_compile | :before_headers | :after_headers | :after_all].
 
 show_env_vars_in_log:                # optional. Set to '0' if you want to hide environment variables, any other values will allow them.
+
+always_out_of_date:                  # optional. Set to '1' if the script should always run without dependency analysis.
 ```
 
 - If you use the `script_path option`, create the script file

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ output_file_list_paths:              # optional.
 dependency_file:                     # optional.
 
 execution_position:                  # optional. [:before_compile | :after_compile | :before_headers | :after_headers | :after_all].
+
+show_env_vars_in_log:                # optional. Set to '0' if you want to hide environment variables, any other values will allow them.
 ```
 
 - If you use the `script_path option`, create the script file

--- a/lib/spinjector/entity/script.rb
+++ b/lib/spinjector/entity/script.rb
@@ -1,7 +1,7 @@
 
 class Script
 
-    attr_reader :name, :source_code, :shell_path, :input_paths, :output_paths, :input_file_list_paths, :output_file_list_paths, :dependency_file, :execution_position, :show_env_vars_in_log
+    attr_reader :name, :source_code, :shell_path, :input_paths, :output_paths, :input_file_list_paths, :output_file_list_paths, :dependency_file, :execution_position, :show_env_vars_in_log, :always_out_of_date
 
     def initialize(
         name,
@@ -13,7 +13,8 @@ class Script
         output_file_list_paths,
         dependency_file,
         execution_position,
-        show_env_vars_in_log
+        show_env_vars_in_log,
+        always_out_of_date
     )
         @name = name
         @source_code = source_code
@@ -25,6 +26,7 @@ class Script
         @dependency_file = dependency_file
         @execution_position = execution_position
         @show_env_vars_in_log = show_env_vars_in_log
+        @always_out_of_date = always_out_of_date
         verify()
     end
 

--- a/lib/spinjector/project_service.rb
+++ b/lib/spinjector/project_service.rb
@@ -138,6 +138,9 @@ class ProjectService
         if script_configuration.show_env_vars_in_log == '0'
             existing_phase.show_env_vars_in_log = script_configuration.show_env_vars_in_log
         end
+        if script_configuration.always_out_of_date == '1'
+            existing_phase.always_out_of_date = script_configuration.always_out_of_date
+        end
     end
 
     # @param [Xcodeproj::Project::Object::PBXNativeTarget] target where build phases should be reordered

--- a/lib/spinjector/project_service.rb
+++ b/lib/spinjector/project_service.rb
@@ -137,9 +137,13 @@ class ProjectService
         # gets set to '0' if the user has explicitly disabled this.
         if script_configuration.show_env_vars_in_log == '0'
             existing_phase.show_env_vars_in_log = script_configuration.show_env_vars_in_log
+        else
+            existing_phase.show_env_vars_in_log = nil
         end
         if script_configuration.always_out_of_date == '1'
             existing_phase.always_out_of_date = script_configuration.always_out_of_date
+        else
+            existing_phase.always_out_of_date = nil
         end
     end
 

--- a/lib/spinjector/script_mapper.rb
+++ b/lib/spinjector/script_mapper.rb
@@ -19,7 +19,8 @@ class ScriptMapper
             @script_hash["output_file_list_paths"] || [],
             @script_hash["dependency_file"],
             @script_hash["execution_position"] || :before_compile,
-            @script_hash["show_env_vars_in_log"]
+            @script_hash["show_env_vars_in_log"],
+            @script_hash["always_out_of_date"]
         )
     end
 

--- a/test/fixtures/execution_with_resettable_flags.yaml
+++ b/test/fixtures/execution_with_resettable_flags.yaml
@@ -1,0 +1,11 @@
+scripts:
+  my_script:
+    name: "My Script"
+    script: |
+      echo my_script
+    show_env_vars_in_log: '0'
+    always_out_of_date: '1'
+
+targets:
+  EmptyProject:
+    - my_script

--- a/test/fixtures/execution_without_resettable_flags.yaml
+++ b/test/fixtures/execution_without_resettable_flags.yaml
@@ -1,0 +1,9 @@
+scripts:
+  my_script:
+    name: "My Script"
+    script: |
+      echo my_script
+
+targets:
+  EmptyProject:
+    - my_script

--- a/test/fixtures/parser.yaml
+++ b/test/fixtures/parser.yaml
@@ -5,6 +5,7 @@ scripts:
       echo Foo
     execution_position: :after_compile
     show_env_vars_in_log: "0"
+    always_out_of_date: "1"
   defaults:
     name: "Defaults"
     script: |

--- a/test/fixtures/parser.yaml
+++ b/test/fixtures/parser.yaml
@@ -4,7 +4,13 @@ scripts:
     script: |
       echo Foo
     execution_position: :after_compile
+    show_env_vars_in_log: "0"
+  defaults:
+    name: "Defaults"
+    script: |
+      echo Defaults
 
 targets:
   Main:
     - foo
+    - defaults

--- a/test/yaml_parser_test.rb
+++ b/test/yaml_parser_test.rb
@@ -16,6 +16,7 @@ class YamlParserTest < TestCase
     assert_equal script.name, "Foo"
     assert_equal script.execution_position, :after_compile
     assert_equal script.show_env_vars_in_log, "0"
+    assert_equal script.always_out_of_date, "1"
 
     default_values_script = target.scripts[1]
     refute_nil default_values_script
@@ -27,5 +28,6 @@ class YamlParserTest < TestCase
     assert_nil default_values_script.dependency_file
     assert_equal default_values_script.execution_position, :before_compile
     assert_nil default_values_script.show_env_vars_in_log
+    assert_nil default_values_script.always_out_of_date
   end
 end

--- a/test/yaml_parser_test.rb
+++ b/test/yaml_parser_test.rb
@@ -15,5 +15,17 @@ class YamlParserTest < TestCase
     refute_nil script
     assert_equal script.name, "Foo"
     assert_equal script.execution_position, :after_compile
+    assert_equal script.show_env_vars_in_log, "0"
+
+    default_values_script = target.scripts[1]
+    refute_nil default_values_script
+    assert_equal default_values_script.name, "Defaults"
+    assert_equal default_values_script.input_paths, []
+    assert_equal default_values_script.output_paths, []
+    assert_equal default_values_script.input_file_list_paths, []
+    assert_equal default_values_script.output_file_list_paths, []
+    assert_nil default_values_script.dependency_file
+    assert_equal default_values_script.execution_position, :before_compile
+    assert_nil default_values_script.show_env_vars_in_log
   end
 end


### PR DESCRIPTION
This Pull Request adds a new option (`always_out_of_date`) on script that allow to make it on each build without Xcode emitting this warning:

> Run script build phase '[SPI] SwiftLint' will be run during every build because it does not specify any outputs. To address this warning, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase.
